### PR TITLE
feat: 약속 생성 api 암호 프로토콜 적용 (#27)

### DIFF
--- a/src/main/java/timetogeter/context/promise/application/service/PromiseManageInfoService.java
+++ b/src/main/java/timetogeter/context/promise/application/service/PromiseManageInfoService.java
@@ -146,7 +146,7 @@ public class PromiseManageInfoService {
 
     //약속 만들기 - 약속 만들고 알림 보내기 Step3 - 서브 서비스 메소드(1)
     @Transactional
-    private Promise createPromise(CreatePromiseAlimRequest3 request) {
+    public Promise createPromise(CreatePromiseAlimRequest3 request) {
         Promise promise = Promise.of(
                 request.groupId(),
                 request.title(),
@@ -163,7 +163,7 @@ public class PromiseManageInfoService {
 
     //약속 만들기 - 약속 만들고 알림 보내기 Step4 - 메인 서비스 메소드
     @Transactional
-    public CreatePromiseAlimResponse4 createPromise4(String userId, CreatePromiseAlimRequest4 request) {
+    public CreatePromiseAlimResponse4 createPromise4(CreatePromiseAlimRequest4 request) {
 
         String groupId = request.groupId();
         List<String> encUserIdList = request.encUserIdList();

--- a/src/main/java/timetogeter/context/promise/presentation/controller/PromiseManageController.java
+++ b/src/main/java/timetogeter/context/promise/presentation/controller/PromiseManageController.java
@@ -147,7 +147,7 @@ public class PromiseManageController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestBody CreatePromiseAlimRequest4 request) throws Exception{
         String userId = userPrincipal.getId();
-        CreatePromiseAlimResponse4 response = promiseManageInfoService.createPromise4(userId,request);
+        CreatePromiseAlimResponse4 response = promiseManageInfoService.createPromise4(request);
         return SuccessResponse.from(response);
     }
 

--- a/src/test/java/timetogeter/context/promise/presentation/controller/PromiseManageControllerTest.java
+++ b/src/test/java/timetogeter/context/promise/presentation/controller/PromiseManageControllerTest.java
@@ -38,8 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -590,6 +589,219 @@ class PromiseManageControllerTest extends RestDocsSupport {
                             )
                     ));
         }*/
+
+
+
+
+    }
+
+    @Nested
+    @DisplayName("약속 알림 수락 API (/api/v1/promise/create/join)")
+    class joinPromise{
+
+        @Test
+        @DisplayName("✅ 약속 참여 알림 수락 Step1 (/api/v1/promise/create/join1)")
+        @WithMockUser
+        void testPromiseJoin1() throws Exception {
+            // given
+            RegisterUserCommand dto = new RegisterUserCommand(
+                    "bloomberg", "bloomberg@gmail.com",
+                    "010-1234-5678", "bloombergNickname", Provider.GENERAL, Role.USER, "20", Gender.MALE
+            );
+            User user = new User(dto);
+            RegisterResponse registerResponse = RegisterResponse.from(user);
+            UserPrincipal userPrincipal = new UserPrincipal(registerResponse);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userPrincipal, null, userPrincipal.getAuthorities()
+            );
+
+            String groupId = "5e9c0739-1717-4574-84c7-60515c21284a";
+            String encGroupId = "pA53EOSdisanosC4/oguf2P+TanvZhPdBcilpVNVDLqHAZZEYJFJN3mMqaKyyHaAK3rnyQ==";
+
+            CreateJoinPromiseRequest1 request = new CreateJoinPromiseRequest1(groupId, encGroupId);
+
+            CreateJoinPromiseResponse1 mockResponse = new CreateJoinPromiseResponse1(
+                    "0gl/Hef+gY/93NjFsN1YPwbyUee4Yw+bAqzm/D5Rd8CaeJ8YzH3Nm6K13x/pO5zLnMplUA=="
+            );
+
+            given(promiseManageInfoService.createJoinPromise1(eq(userPrincipal.getId()),any(CreateJoinPromiseRequest1.class)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/promise/create/join1")
+                            .with(authentication(authentication))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                    .andExpect(jsonPath("$.data.encencGroupMemberId").value(mockResponse.encencGroupMemberId()))
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("Step1 - 그룹 참여 요청 시 encGroupId를 보내고 encencGroupMemberId를 응답받는다.")
+                                            .requestFields(
+                                                    fieldWithPath("groupId").type(JsonFieldType.STRING).description("참여할 그룹 ID"),
+                                                    fieldWithPath("encGroupId").type(JsonFieldType.STRING).description("개인키로 암호화된 그룹 ID")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.encencGroupMemberId").type(JsonFieldType.STRING).description("서버가 추가 암호화한 그룹멤버 ID")
+                                            )
+                                            .build()
+                            )
+                    ));
+
+        }
+
+        @Test
+        @DisplayName("✅ 약속 참여 알림 수락 Step2 (/api/v1/promise/create/join2)")
+        @WithMockUser(username = "mockUserId")
+        void testCreateJoinPromise2() throws Exception {
+            // given
+            String encUserId = "Cb1n3T8pwO/LyxBuR81vcf+k1TvhXgIK/A==";
+            String groupId = "5e9c0739-1717-4574-84c7-60515c21284a";
+            CreateJoinPromiseRequest2 request = new CreateJoinPromiseRequest2(encUserId, groupId);
+
+            CreateJoinPromiseResponse2 mockResponse = new CreateJoinPromiseResponse2(
+                    "2C86SvvD3azjoYXwu+1CPGKiDMSSVBnNQCp3Fo9azTwJjOIRRp+K7A=="
+            );
+
+            given(promiseManageInfoService.createJoinPromise2(any(CreateJoinPromiseRequest2.class)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/promise/create/join2")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                    .andExpect(jsonPath("$.data.encGroupKey").value(mockResponse.encGroupKey()))
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("Step2 - encencGroupMemberId 복호화 후 encUserId, groupId를 보내면 encGroupKey를 응답받음")
+                                            .requestFields(
+                                                    fieldWithPath("encUserId").type(JsonFieldType.STRING).description("개인키로 복호화한 암호화된 사용자 ID"),
+                                                    fieldWithPath("groupId").type(JsonFieldType.STRING).description("참여 그룹 ID")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.encGroupKey").type(JsonFieldType.STRING).description("암호화된 그룹 키")
+                                            )
+                                            .build()
+                            )
+                    ));
+        }
+
+
+        @Test
+        @DisplayName("✅ 약속 참여 알림 수락 Step3 (/api/v1/promise/create/join3)")
+        @WithMockUser(username = "mockUserId")
+        void testCreateJoinPromise3() throws Exception {
+            // given
+            String encUserId = "Cb1n3T8pwO/LyxBuR81vcf+k1TvhXgIK/A==";
+            CreateJoinPromiseRequest3 request = new CreateJoinPromiseRequest3(encUserId);
+
+            String mockValue = "55Nfbri0tOQpJs58WZgZhSJI3SC2Lh9Zx/Iq5xGLVx55fDQqIs20FQ==::01bb0b8f-ea3f-4d0d-8ed8-8b6ce07ca665";
+            CreateJoinPromiseResponse3 mockResponse = new CreateJoinPromiseResponse3(mockValue);
+
+            given(promiseManageInfoService.createJoinPromise3(any(CreateJoinPromiseRequest3.class)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/promise/create/join3")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                    .andExpect(jsonPath("$.data.value").value(mockValue))
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("Step3 - encUserId를 보내 Redis에서 'PENDING' 상태인 알림 값 조회 및 반환")
+                                            .requestFields(
+                                                    fieldWithPath("encUserId").type(JsonFieldType.STRING).description("암호화된 사용자 ID")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.value").type(JsonFieldType.STRING).description("알림값")
+                                            )
+                                            .build()
+                            )
+                    ));
+        }
+
+
+        @Test
+        @DisplayName("✅ 약속 참여 알림 수락 Step4 (/api/v1/promise/create/join4)")
+        @WithMockUser
+        void testCreateJoinPromise4() throws Exception {
+            // given
+            RegisterUserCommand dto = new RegisterUserCommand(
+                    "bloomberg", "bloomberg@gmail.com",
+                    "010-1234-5678", "bloombergNickname", Provider.GENERAL, Role.USER, "20", Gender.MALE
+            );
+            User user = new User(dto);
+            RegisterResponse registerResponse = RegisterResponse.from(user);
+            UserPrincipal userPrincipal = new UserPrincipal(registerResponse);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userPrincipal, null, userPrincipal.getAuthorities()
+            );
+
+            CreateJoinPromiseRequest4 request = new CreateJoinPromiseRequest4(
+                    "oVosEeTIgZmn9pa6r4guLmSuTam+YRzdC5qm9wMGCejUD5QQ/7ITXNm/O5GuXli7/K9rsA==",
+                    "8wchHLnI3I3t7wnc4koeSHMIhMY6jjNX+A=",
+                    "Cb1n3T8pwO/LyxBuR81vcf+k1TvhXgIK/A==",
+                    "/w5hEaXd94b7pK2xvfItJRyFKPCzVBnNnB/WYzX0B/hoy0DU3JzM1w=="
+            );
+
+            CreateJoinPromiseResponse4 mockResponse = new CreateJoinPromiseResponse4("약속 참여를 수락하셨습니다.");
+
+            given(promiseManageInfoService.createJoinPromise4(eq(userPrincipal.getId()), any(CreateJoinPromiseRequest4.class)))
+                    .willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/promise/create/join4")
+                            .with(authentication(authentication))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                    .andExpect(jsonPath("$.data.message").value("약속 참여를 수락하셨습니다."))
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("Step4 - 약속 참여 수락 후 관련 테이블 저장")
+                                            .requestFields(
+                                                    fieldWithPath("encPromiseId").type(JsonFieldType.STRING).description("암호화된 약속 ID"),
+                                                    fieldWithPath("encPromiseMemberId").type(JsonFieldType.STRING).description("암호화된 약속원 ID"),
+                                                    fieldWithPath("encUserId").type(JsonFieldType.STRING).description("암호화된 사용자 ID"),
+                                                    fieldWithPath("encPromiseKey").type(JsonFieldType.STRING).description("암호화된 약속 키")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.message").type(JsonFieldType.STRING).description("응답 상세 메시지")
+                                            )
+                                            .build()
+                            )
+                    ));
+        }
+
+
 
 
     }

--- a/src/test/java/timetogeter/context/promise/presentation/controller/PromiseManageControllerTest.java
+++ b/src/test/java/timetogeter/context/promise/presentation/controller/PromiseManageControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -22,10 +23,6 @@ import timetogeter.context.auth.domain.entity.User;
 import timetogeter.context.auth.domain.vo.Gender;
 import timetogeter.context.auth.domain.vo.Provider;
 import timetogeter.context.auth.domain.vo.Role;
-import timetogeter.context.group.application.dto.request.ViewGroup2Request;
-import timetogeter.context.group.application.dto.response.ViewGroup1Response;
-import timetogeter.context.group.application.dto.response.ViewGroup2Response;
-import timetogeter.context.group.application.dto.response.ViewGroup3Response;
 import timetogeter.context.group.application.service.GroupManageDisplayService;
 import timetogeter.context.group.application.service.GroupManageInfoService;
 import timetogeter.context.group.application.service.GroupManageMemberService;
@@ -36,15 +33,17 @@ import timetogeter.context.promise.domain.vo.PromiseType;
 import timetogeter.global.RestDocsSupport;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -63,11 +62,11 @@ class PromiseManageControllerTest extends RestDocsSupport {
     @MockBean
     private GroupManageMemberService groupManageMemberService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @MockBean
     private PromiseManageInfoService promiseManageInfoService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private Authentication authentication;
 
@@ -461,12 +460,24 @@ class PromiseManageControllerTest extends RestDocsSupport {
                     ));
         }
 
-        //TODO: 아래 테스트 코드 500 오류 버그 (실제 실행시 결과json 잘 나오는 상태)
-        /*@Test
+
+        @Test
         @DisplayName("✅ 약속 내 예비 약속원들의 개인키로 암호화한 그룹키 리스트 반환 (/api/v1/promise/create4)")
         @WithMockUser
         void testPromiseCreate4() throws Exception {
             // given
+            RegisterUserCommand dto = new RegisterUserCommand(
+                    "bloomberg", "bloomberg@gmail.com",
+                    "010-1234-5678", "bloombergNickname", Provider.GENERAL, Role.USER, "20", Gender.MALE
+            );
+            User user = new User(dto);
+            RegisterResponse registerResponse = RegisterResponse.from(user);
+            UserPrincipal userPrincipal = new UserPrincipal(registerResponse);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userPrincipal, null, userPrincipal.getAuthorities()
+            );
+
             List<String> encUserIdList = List.of(
                     "Cr9nxjou18jf38nu0aJ4Iyn9tDLVvzT37qMD",
                     "Cb1n3T8pwO/LyxBuR81vcf+k1TvhXgIK/A=="
@@ -481,11 +492,12 @@ class PromiseManageControllerTest extends RestDocsSupport {
             );
             CreatePromiseAlimResponse4 response = new CreatePromiseAlimResponse4(encGroupKeyList);
 
-            given(promiseManageInfoService.createPromise4(anyString(), any(CreatePromiseAlimRequest4.class)))
+            given(promiseManageInfoService.createPromise4(any(CreatePromiseAlimRequest4.class)))
                     .willReturn(response);
 
             // when, then
             mockMvc.perform(post("/api/v1/promise/create4")
+                            .with(authentication(authentication))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andDo(print())
@@ -494,18 +506,91 @@ class PromiseManageControllerTest extends RestDocsSupport {
                     .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
                     .andExpect(jsonPath("$.data.encGroupKeyList[0]").value(encGroupKeyList.get(0)))
                     .andExpect(jsonPath("$.data.encGroupKeyList[1]").value(encGroupKeyList.get(1)))
-                    .andDo(document("promise-create4",
-                            requestFields(
-                                    fieldWithPath("encUserIdList").description("암호화된 사용자 ID 리스트"),
-                                    fieldWithPath("groupId").description("그룹 ID")
-                            ),
-                            responseFields(
-                                    fieldWithPath("code").description("응답 코드"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("data.encGroupKeyList").description("암호화된 그룹키 리스트")
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("예비 약속원들의 개인키로 암호화한 그룹키 리스트를 반환한다.")
+                                            .requestFields(
+                                                    fieldWithPath("encUserIdList").type(JsonFieldType.ARRAY).description("암호화된 사용자 ID 리스트"),
+                                                    fieldWithPath("groupId").type(JsonFieldType.STRING).description("그룹 ID")
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.encGroupKeyList").type(JsonFieldType.ARRAY).description("암호화된 그룹키 리스트")
+                                            )
+                                            .build()
+                            )
+                    ));
+
+        }
+
+        //TODO: 아래 테스트 코드 500 오류 버그 (실제 실행시에는 결과json 잘 나오는 상태)
+        /*@Test
+        @DisplayName("✅ 약속을 최종적으로 만들었다. (/api/v1/promise/create5)")
+        @WithMockUser
+        void testPromiseCreate5() throws Exception {
+            // given
+            List<HashMap<String, Integer>> list = List.of(
+                    new HashMap<>(Map.of("Cr9nxjou18jf38nu0aJ4Iyn9tDLVvzT37qMD", 1)),
+                    new HashMap<>(Map.of("Cb1n3T8pwO/LyxBuR81vcf+k1TvhXgIK/A==", 1))
+            );
+            CreatePromiseAlimRequest5 request = new CreatePromiseAlimRequest5(
+                    "01bb0b8f-ea3f-4d0d-8ed8-8b6ce07ca665",
+                    "3gAi1rYpK3XEf+3uwN3gZ6giA1UHe0pgnU9i9GevVrHvrywsJl6IbqMGAhfE3EdmJat+Iw==",
+                    "j18vwO4uYUaaf/6eGB49N4TzCiw0bneYx7P8",
+                    "Cr9nxjou18jf38nu0aJ4Iyn9tDLVvzT37qMD",
+                    "gFRv1vc8XWqYLdbl0qfjbNAJZgwKTk9wAFzyVbGMGn5pioj1YggyNQ==",
+                    List.of(
+                            "5zs5+VGE5Myi5Nd6k5XFQb0a4t9yLU3xDHFznVJHEV1jVUOO70gIeQ==",
+                            "55Nfbri0tOQpJs58WZgZhSJI3SC2Lh9Zx/Iq5xGLVx55fDQqIs20FQ=="
+                    ),
+                    list
+            );
+
+            CreatePromiseAlimResponse5 response = new CreatePromiseAlimResponse5("약속 생성 및 알림 전송 완료");
+
+            given(promiseManageInfoService.createPromise5(anyString(), any(CreatePromiseAlimRequest5.class)))
+                    .willReturn(response);
+
+            // when, then
+            mockMvc.perform(post("/api/v1/promise/create5")
+                            .with(authentication(authentication))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                    .andExpect(jsonPath("$.data.message").value("약속 생성 및 알림 전송 완료"))
+                    .andDo(restDocs.document(
+                            resource(
+                                    ResourceSnippetParameters.builder()
+                                            .tag("약속 관련 API")
+                                            .description("약속을 최종 생성하고 알림을 전송한다.")
+                                            .requestFields(
+                                                    fieldWithPath("promiseId").type(JsonFieldType.STRING).description("약속 ID"),
+                                                    fieldWithPath("encPromiseId").type(JsonFieldType.STRING).description("암호화된 약속 ID"),
+                                                    fieldWithPath("encPromiseMemberId").type(JsonFieldType.STRING).description("암호화된 약속원 ID"),
+                                                    fieldWithPath("encUserId").type(JsonFieldType.STRING).description("암호화된 사용자 ID"),
+                                                    fieldWithPath("encPromiseKey").type(JsonFieldType.STRING).description("암호화된 약속 키"),
+                                                    fieldWithPath("encEncGroupKeyList").type(JsonFieldType.ARRAY).description("암호화된 그룹키 리스트"),
+                                                    fieldWithPath("whichEncUserIdsIn")
+                                                            .ignored()
+                                                            .attributes(key("description").value("암호화된 사용자 ID를 키로, 1을 값으로 갖는 단일 key-value 맵의 배열. 예: [{\"암호화ID\": 1}, ...]"))
+
+                                            )
+                                            .responseFields(
+                                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                    fieldWithPath("data.message").type(JsonFieldType.STRING).description("응답 상세 메시지")
+                                            )
+                                            .build()
                             )
                     ));
         }*/
+
 
     }
 


### PR DESCRIPTION
## 약속 생성 api 구현
### 📌 closes #27 

### 📝 요약
- 약속 생성 api는 아래와 같이 3단계로 나누어 암호 프로토콜을 적용했습니다.
1. 약속 만들기 화면 보여주기 api (약속 만드는 사람)
2. 약속 만들기 - 약속 만들고 알림 보내기 api (약속 만드는 사람)
3. 약속 만들기 - 약속 참여 알림 수락 api (예비 약속참여하는 사람)

### 🔎 작업 내용

- 특히 2번의 경우 5단계로 나누어 작업했습니다.
<img width="577" alt="image" src="https://github.com/user-attachments/assets/b17ddb1e-2460-41cd-abe8-45dcd13e2d7b" />

- restdocs 에서 동적 키는 문서화할 수 없어 2번의 5번째에서 오류가 나는 상황입니다. 

### 🛠️ 변경 사항
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [x] 로직에 영향을 미치지 않는 수정(주석 수정, 오타 수정 등)
- [ ] 문서 수정
- [ ] 테스트 코드
- [ ] 파일 구조 변경
